### PR TITLE
Allow MSI files to contain Windows API functionality

### DIFF
--- a/Windows_API_Function.yar
+++ b/Windows_API_Function.yar
@@ -68,5 +68,8 @@ rule Windows_API_Function
         or
         /* trigger = 'PE' */
         (uint16be(uint32(0x3c)) == 0x5045)
+        or
+        /* MSI */
+        (uint32be(0x0) == 0xd0cf11e0)
     )
 }


### PR DESCRIPTION
Microsoft Installer files may contain custom action DLLs in an uncompressed form. It is expected for those custom action DLLs to contain Windows API calls.